### PR TITLE
update readme with rails 2 specific instructions

### DIFF
--- a/README
+++ b/README
@@ -24,7 +24,7 @@ Installation
 Install Rails Footnotes is very easy. If you are running on Rails 2.3 just run
 the following:
 
-   sudo gem install rails-footnotes
+  gem install rails-footnotes -v 3.6.7
 
 In RAILS_ROOT/config/environments/development.rb (yes, you want it only in development):
 
@@ -32,7 +32,7 @@ In RAILS_ROOT/config/environments/development.rb (yes, you want it only in devel
 
 If you want it as plugin, just do:
 
-   script/plugin install git://github.com/josevalim/rails-footnotes.git
+  script/plugin install git://github.com/josevalim/rails-footnotes.git -r rails2
 
 Configuration
 -------------


### PR DESCRIPTION
Was using rails-footnotes on a legacy codebase today (thanks) and found the instructions in the README didn't work with the rails2 fork.  Just making a couple changes:
- Change the gem install command to use what i understand to be the last rails 2 compatible version
- Remove sudo from gem install command (rvm users won't want that)
- Add the -r switch with rails2 branch name to the script/install command so you get the rails2 branch in your plugins directory.
