### PR TITLE
Double-clearing the @@log variable is wrong

### DIFF
--- a/lib/rails-footnotes/notes/log_note.rb
+++ b/lib/rails-footnotes/notes/log_note.rb
@@ -22,7 +22,6 @@ module Footnotes
       def log
         unless @log
           @log = @@log.join('')
-          @@log = []
           if rindex = @log.rindex('Processing '+@controller.class.name+'#'+@controller.action_name)
             @log = @log[rindex..-1]
           end


### PR DESCRIPTION
When the partials note calls #log the side effect is to clear LogNote's @@log which is shared between the LogNote and PartialsNote (which inherits) from LogNote. This caused my Log note to always be blank. Am I missing something?
