### PR TITLE
fix CookiesNote

### DIFF
--- a/lib/rails-footnotes/notes/cookies_note.rb
+++ b/lib/rails-footnotes/notes/cookies_note.rb
@@ -2,7 +2,7 @@ module Footnotes
   module Notes
     class CookiesNote < AbstractNote
       def initialize(controller)
-        @cookies = controller.__send__(:cookies)
+        @cookies = controller.request.env["rack.request.cookie_hash"].nil? ? {} : controller.request.env["rack.request.cookie_hash"].dup
       end
 
       def title


### PR DESCRIPTION
I am able to recreate the problem reported by @jrimmer in #45 using rails-footnotes v3.7.5rc1 and rails 3.1.0 rc5 and rails master. This patch fixes the problem. 
