### PR TITLE
Fix exception when controller_filename is nil

### DIFF
--- a/lib/rails-footnotes/notes/controller_note.rb
+++ b/lib/rails-footnotes/notes/controller_note.rb
@@ -14,7 +14,7 @@ module Footnotes
       end
 
       def valid?
-        prefix? && File.exists?(self.controller_filename)
+        prefix? && self.controller_filename && File.exists?(self.controller_filename)
       end
 
       protected


### PR DESCRIPTION
Using 3.7.5 with Rails 3.1.1 and ActiveAdmin 0.3.2

```
Footnotes Footnotes::Notes::ControllerNote Exception: can't convert nil into String
/lib/rails-footnotes/notes/controller_note.rb:17:in `exists?'
/lib/rails-footnotes/notes/controller_note.rb:17:in `valid?'
/lib/rails-footnotes/footnotes.rb:133:in `block in initialize_notes!'
/lib/rails-footnotes/footnotes.rb:62:in `block in each_with_rescue'
/lib/rails-footnotes/footnotes.rb:60:in `each'
/lib/rails-footnotes/footnotes.rb:60:in `each_with_rescue'
/lib/rails-footnotes/footnotes.rb:355:in `each_with_rescue'
/lib/rails-footnotes/footnotes.rb:131:in `initialize_notes!'
/lib/rails-footnotes/footnotes.rb:125:in `add_footnotes_without_validation!'
/lib/rails-footnotes/footnotes.rb:102:in `add_footnotes!'
```
