### PR TITLE
ActionController::Streaming#send_file responses zero byte file.

### DIFF
--- a/lib/rails-footnotes/footnotes.rb
+++ b/lib/rails-footnotes/footnotes.rb
@@ -94,8 +94,11 @@ module Footnotes
     def initialize(controller)
       @controller = controller
       @template = controller.instance_variable_get(:@template)
-      @body = controller.response.body
       @notes = []
+
+      revert_pos(controller.response_body) do
+        @body = controller.response.body
+      end
     end
 
     def add_footnotes!
@@ -132,6 +135,13 @@ module Footnotes
           note = klass.new(@controller)
           @notes << note if note.respond_to?(:valid?) && note.valid?
         end
+      end
+
+      def revert_pos(file)
+        return yield unless file.respond_to?(:pos) && file.respond_to?(:pos=)
+        original = file.pos
+        yield
+        file.pos = original
       end
 
       def performed_render?

--- a/spec/footnotes_spec.rb
+++ b/spec/footnotes_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require 'action_controller'
 require 'action_controller/test_case'
+require "tempfile"
 
 class FootnotesController < ActionController::Base
   attr_accessor :template, :performed_render
@@ -34,6 +35,25 @@ describe "Footnotes" do
   it "footnotes_controller" do
     index = @controller.response.body.index(/This is the HTML page/)
     index.should eql 334
+  end
+
+  context "response_body is file" do
+    before do
+      @file = Tempfile.new("test")
+      @file.write "foobarbaz"
+      @file.rewind
+    end
+
+    after do
+      @file.close!
+    end
+
+    it "should not change file position" do
+      @controller.response_body = @file
+      expect {
+        @footnotes = Footnotes::Filter.new(@controller)
+      }.not_to change{ @controller.response_body.pos }
+    end
   end
 
   #TODO doe's not pased with 1.8.7


### PR DESCRIPTION
When Rails.configuration.action_dispatch.x_sendfile_header is blank, ActionController::Streaming#send_file responses zero byte file.

This issue is caused by changing file position by calling "controller.response.body" in Footnotes::Filter#initialize.
