### PR TITLE
really fix asset pipeline >3.1 to list .js.erb and .css.scss files properly, and improve implementation

### DIFF
--- a/lib/rails-footnotes/notes/files_note.rb
+++ b/lib/rails-footnotes/notes/files_note.rb
@@ -14,7 +14,7 @@ module Footnotes
         if @files.empty?
           ""
         else
-          "<ul><li>#{@files.join("</li><li>")}</li></ul>"
+          "<ul><li>%s</li></ul>" % @files.join("</li><li>")
         end
       end
 
@@ -28,12 +28,30 @@ module Footnotes
         end
 
         def parse_files!
-          @files.collect! do |filename|
-            if filename =~ %r{^/}
-              full_filename = File.join(File.expand_path(Rails.root), 'public', filename)
-              %[<a href="#{Footnotes::Filter.prefix(full_filename, 1, 1)}">#{filename}</a>]
-            else
-              %[<a href="#{filename}">#{filename}</a>]
+          if Rails::VERSION::STRING.to_f >= 3.1 && Rails.application.config.assets[:enabled]
+            asset_paths = Rails.application.config.assets.paths
+            linked_files = []
+
+            @files.collect do |file|
+              base_name = File.basename(file)
+              asset_paths.each do |asset_path|
+                results = Dir[File.expand_path(base_name, asset_path) + '*']
+                results.each do |r|
+                  linked_files << %[<a href="#{Footnotes::Filter.prefix(r, 1, 1)}">#{File.basename(r)}</a>]
+                end
+                break if results.present?
+              end
+            end
+            @files = linked_files
+          else
+            #Original Implementation
+            @files.collect! do |filename|
+              if filename =~ %r{^/}
+                full_filename = File.join(File.expand_path(Rails.root), 'public', filename)
+                %[<a href="#{Footnotes::Filter.prefix(full_filename, 1, 1)}">#{filename}</a>]
+              else
+                %[<a href="#{filename}">#{filename}</a>]
+              end
             end
           end
         end


### PR DESCRIPTION
This is a competing fix for https://github.com/josevalim/rails-footnotes/pull/56
- Get rid of regexp based filename manipulation, as this is unportable.
- Take the fact that resources can have more extensions.  e.g. .js.erb, .css.scss.erb
