### PR TITLE
Fix assigns_note to gnore assigns starts with '@_'

### DIFF
--- a/lib/rails-footnotes/notes/assigns_note.rb
+++ b/lib/rails-footnotes/notes/assigns_note.rb
@@ -16,6 +16,8 @@ module Footnotes
                             :@view_runtime
                           ]
       cattr_accessor :ignored_assigns, :instance_writter => false
+      @@ignored_assigns_pattern = /^@_/
+      cattr_accessor :ignored_assigns_pattern, :instance_writter => false
 
       def initialize(controller)
         @controller = controller
@@ -39,7 +41,7 @@ module Footnotes
         end
 
         def assigns
-          @assigns ||= @controller.instance_variables.map {|v| v.to_sym} - ignored_assigns
+          @assigns ||= @controller.instance_variables.map {|v| v.to_sym}.select {|v| v !~ ignored_assigns_pattern } - ignored_assigns
         end
 
         def assigned_value(key)

--- a/spec/notes/assigns_note_spec.rb
+++ b/spec/notes/assigns_note_spec.rb
@@ -5,9 +5,9 @@ require "rails-footnotes/notes/assigns_note"
 describe Footnotes::Notes::AssignsNote do
   let(:note) do
     @controller = mock
-    @controller.stub(:instance_variables).and_return([:@action_has_layout, :@_status])
+    @controller.stub(:instance_variables).and_return([:@action_has_layout, :@status])
     @controller.instance_variable_set(:@action_has_layout, true)
-    @controller.instance_variable_set(:@_status, 200)
+    @controller.instance_variable_set(:@status, 200)
     Footnotes::Notes::AssignsNote.new(@controller)
   end
   subject {note}
@@ -17,17 +17,22 @@ describe Footnotes::Notes::AssignsNote do
   it {should be_valid}
   its(:title) {should eql 'Assigns (2)'}
 
-  specify {note.send(:assigns).should eql [:@action_has_layout, :@_status]}
-  specify {note.send(:to_table).should eql [['Name', 'Value'], [:@action_has_layout, "true"], [:@_status, "200"]]}
+  specify {note.send(:assigns).should eql [:@action_has_layout, :@status]}
+  specify {note.send(:to_table).should eql [['Name', 'Value'], [:@action_has_layout, "true"], [:@status, "200"]]}
 
   describe "Ignored Assigns" do
-    before(:each) {Footnotes::Notes::AssignsNote.ignored_assigns = [:@_status]}
-    it {note.send(:assigns).should_not include :@_status}
+    before(:each) {Footnotes::Notes::AssignsNote.ignored_assigns = [:@status]}
+    it {note.send(:assigns).should_not include :@status}
+  end
+
+  describe "Ignored Assigns by regexp" do
+    before(:each) {Footnotes::Notes::AssignsNote.ignored_assigns_pattern = /^@status$/}
+    it {note.send(:assigns).should_not include :@status}
   end
 
   it "should call #mount_table method with correct params" do
     note.should_receive(:mount_table).with(
-      [['Name', 'Value'], [:@action_has_layout, "true"], [:@_status, "200"]], {:summary=>"Debug information for Assigns (2)"})
+      [['Name', 'Value'], [:@action_has_layout, "true"], [:@status, "200"]], {:summary=>"Debug information for Assigns (2)"})
     note.content
   end
 end


### PR DESCRIPTION
This patch fixes the issue #70.
