### PR TITLE
Apparently, Filter.prefix is pretty strict on the appearance order of %s...

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -70,6 +70,9 @@ Where you are going to choose a prefix compatible with your text editor. The %s 
 replaced by the name of the file, the first %d is replaced by the line number and
 the second %d is replaced by the column.
 
+Take note that the order in which the file name (%s), line number (%d) and column number (%d) appears is important. 
+We assume that they appear in that order. "foo://line=%d&file=%s" (%d precedes %s) would throw out an error.
+
 By default, footnotes are appended at the end of the page with default stylesheet. If you want
 to change their position, you can define a div with id "footnotes_holder" or define your own stylesheet
 by turning footnotes stylesheet off:


### PR DESCRIPTION
..., %d and %d for the file name, line number and column number in that the %s has to be appear first in the string before any of the %d. Otherwise, you get

Footnotes #Footnotes::Notes::ControllerNote:0x9a5a650 Exception: invalid value for Integer(): "/opt/ror/tribes/app/controllers/dailies_controller.rb"

errors all over the place. I ran into this when I tried writing my own gedit protocol wrapper where I assumed the format to be:

```
foo://l=%d&%s
```

and ran into problems.

Granted that I'm probably an edge case and not a lot of people write their own filter prefixes so this is probably not worth writing code for. Just wanted it to appear in the docs somewhere to spare someone else the trouble I've gone through.
