### PR TITLE
Update README.rdoc to handle invalid single quote

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -76,7 +76,7 @@ We assume that they appear in that order. "foo://line=%d&file=%s" (%d precedes %
 
 *Sublime* *Text* *2*
 
-1. Keep the Textmate prefix, Footnotes::Filter.prefix = 'txmt://open?url=file://%s&line=%d&column=%d'
+1. Keep the Textmate prefix, <tt>Footnotes::Filter.prefix = 'txmt://open?url=file://%s&line=%d&column=%d'</tt>
 
 2. Install {subl-hanlder}[https://github.com/asuth/subl-handler]
 


### PR DESCRIPTION
In the README  **Sublime Text 2** part, when copy & paste the snippet code the single quote is invalid. By wrapping it in a `<tt>` tag can solve that.

![Screen Shot 2013-02-06 at 11 09 00 PM](https://f.cloud.github.com/assets/184520/131637/fd64a902-7066-11e2-907e-2f33e71aa06d.png)
