### PR TITLE
Add pg_namespace to ignored regexps

### DIFF
--- a/lib/rails-footnotes/notes/queries_note.rb
+++ b/lib/rails-footnotes/notes/queries_note.rb
@@ -6,7 +6,7 @@ module Footnotes
       @@alert_sql_number = 8
       @@query_subscriber = nil
       @@orm              = [:active_record, :data_mapper]
-      @@ignored_regexps  = [%r{(pg_table|pg_attribute|show\stables|pragma|sqlite_master)}i]
+      @@ignored_regexps  = [%r{(pg_table|pg_attribute|pg_namespace|show\stables|pragma|sqlite_master)}i]
 
       def self.start!(controller)
         self.query_subscriber.reset!


### PR DESCRIPTION
This is to avoid SQL like this:

``` sql
SELECT COUNT(*) FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind in ('v','r') AND c.relname = '<table_name>' AND n.nspname = ANY (current_schemas(false))
```

Could not find any tests for that.

Thanks
