### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,7 +34,7 @@ In RAILS_ROOT/config/environments/development.rb (yes, you want it only in devel
 For version greater than 3.7.0
 
 If you want to add alternate logic to enable or disable footnotes,
-add something like this to config/initializers/footnotes.rb:
+add something like this to config/initializers/rails_footnotes.rb:
 
   if defined?(Footnotes) && Rails.env.development?
     Footnotes.run! # first of all
@@ -44,7 +44,7 @@ add something like this to config/initializers/footnotes.rb:
 
 === Post initialization
 
-If you want to add alternate logic to config footnotes without commit it to SCM, add your code to .footnotes:
+If you want to add alternate logic to config footnotes without commit it to SCM, add your code to .rails_footnotes:
 
     Footnotes::Filter.notes = []
 


### PR DESCRIPTION
Wrong file names:

  \* config/initializers/footnotes.rb
  \* .footnotes

In version 3.7.9 they are:
  * config/initializers/rails_footnotes.rb
  * .rails_footnotes
