### PR TITLE
Usage of Hash#diff prints a million deprecation warnings to server log

### DIFF
--- a/lib/rails-footnotes/notes/routes_note.rb
+++ b/lib/rails-footnotes/notes/routes_note.rb
@@ -45,10 +45,16 @@ module Footnotes
       # Filter routes according to the filter sent
       #
       def filtered_routes(filter = {})
+        def diff(h1,h2)
+          h1.dup.delete_if { |k, v|
+            h2[k] == v
+          }.merge!(h2.dup.delete_if { |k, v| h1.has_key?(k) })
+        end
+
         return [] unless filter.is_a?(Hash)
         return routes.reject do |r|
-          filter_diff = filter.diff(r.requirements)
-          route_diff  = r.requirements.diff(filter)
+          filter_diff = diff(filter, r.requirements)
+          route_diff  = diff(r.requirements, filter)
           (filter_diff == filter) || (filter_diff != route_diff)
         end
       end


### PR DESCRIPTION
Footnotes::Extensions::Routes::filtered_routes uses Hash#diff which has been deprecated by Rails 4 (or earlier?), see https://github.com/rails/rails/pull/8158. This cause the server to print a bazillion deprecation warnings to the server log on every refresh:

```
DEPRECATION WARNING: Hash#diff is no longer used inside of Rails, and is being deprecated with no replacement. If you're using it to compare hashes for the purpose of testing, please use MiniTest's assert_equal instead. (called from require at bin/rails:4)
DEPRECATION WARNING: Hash#diff is no longer used inside of Rails, and is being deprecated with no replacement. If you're using it to compare hashes for the purpose of testing, please use MiniTest's assert_equal instead. (called from require at bin/rails:4)
DEPRECATION WARNING: Hash#diff is no longer used inside of Rails, and is being deprecated with no replacement. If you're using it to compare hashes for the purpose of testing, please use MiniTest's assert_equal instead. (called from require at bin/rails:4)
...
```

 I just extracted the original diff into a local function without touching the logic in filtered_routes.
