### PR TITLE
Fixes broken links to file in queries stack trace

### DIFF
--- a/lib/rails-footnotes/notes/queries_note.rb
+++ b/lib/rails-footnotes/notes/queries_note.rb
@@ -70,7 +70,7 @@ module Footnotes
       def parse_trace(trace)
         trace.map do |t|
           s = t.split(':')
-          %[<a href="#{escape(Footnotes::Filter.prefix("#{Rails.root.to_s}/#{s[0]}", s[1].to_i, 1))}">#{escape(t)}</a><br />]
+          %[<a href="#{Footnotes::Filter.prefix("#{Rails.root.to_s}/#{s[0]}", s[1].to_i, 1)}">#{escape(t)}</a><br />]
         end.join
       end
     end


### PR DESCRIPTION
Before the fix the links had "&amp;" instead of "&" in the url.

I just removed the "escape" surrounding the url. Was it actually useful in some way ?
