### PR TITLE
Remove duplicate dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rails (>= 3.0.0)
   rails-footnotes!
   rspec (~> 2.9.0)

--- a/rails-footnotes.gemspec
+++ b/rails-footnotes.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.0.0"
 
-  s.add_development_dependency "rails", ">= 3.0.0"
   s.add_development_dependency "rspec", "~> 2.9.0"
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Last bundle with last ruby complains about the duplicate dependency on rails :

```
rails-footnotes at /Users/adrien/.gem/ruby/2.1.0/bundler/gems/rails-footnotes-55871d47fd7e did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on rails (>= 3.0.0, development), (>= 3.0.0) use:
    add_runtime_dependency 'rails', '>= 3.0.0', '>= 3.0.0'
```
