### PR TITLE
update initializer to check if Footnotes is defined

### DIFF
--- a/lib/generators/templates/rails_footnotes.rb
+++ b/lib/generators/templates/rails_footnotes.rb
@@ -1,4 +1,4 @@
-Footnotes.setup do |f|
+defined?(Footnotes) && Footnotes.setup do |f|
   # Wether or not to enable footnotes
   f.enabled = Rails.env.development?
   # You can also use a lambda / proc to conditionally toggle footnotes


### PR DESCRIPTION
Consider this Gemfile:

``` ruby
group :development do
  gem 'rails-footnotes'
end
```

Except development env, rails fail to start because of generated initializer, saying:

```
uninitialized constant Footnotes (NameError)
```
