### PR TITLE
Closes #112 Initializer needs to call super() first in order for patters...

### DIFF
--- a/lib/rails-footnotes/notes/queries_note.rb
+++ b/lib/rails-footnotes/notes/queries_note.rb
@@ -103,6 +103,7 @@ module Footnotes
       attr_accessor :events, :ignore_regexps
 
       def initialize(orm)
+        super() 
         @events = []
         orm.each {|adapter| ActiveSupport::LogSubscriber.attach_to adapter, self}
       end


### PR DESCRIPTION
... to be initialized to an empty array.

See the exception that is raised if not here:

https://github.com/josevalim/rails-footnotes/issues/112

So, this PR, I believe it closes this #112 issue.
