### PR TITLE
assigns note: add variable class, and pretty print ActiveRecord::Relation

### DIFF
--- a/lib/rails-footnotes/filter.rb
+++ b/lib/rails-footnotes/filter.rb
@@ -161,8 +161,10 @@ module Footnotes
           #footnotes_debug a {color: #9b1b1b; font-weight: inherit; text-decoration: none; line-height: 18px;}
           #footnotes_debug table {text-align: left; width: 100%;}
           #footnotes_debug table td {padding: 5px; border-bottom: 1px solid #ccc;}
+          #footnotes_debug table td strong {color: #9b1b1b;}
           #footnotes_debug table th {padding: 5px; border-bottom: 1px solid #ccc;}
           #footnotes_debug table tr:nth-child(2n) td {background: #eee;}
+          #footnotes_debug table tr:nth-child(2n + 1) td {background: #fff;}
           #footnotes_debug tbody {text-align: left;}
           #footnotes_debug .name_values td {vertical-align: top;}
           #footnotes_debug legend {background-color: #fff;}

--- a/lib/rails-footnotes/notes/assigns_note.rb
+++ b/lib/rails-footnotes/notes/assigns_note.rb
@@ -38,7 +38,14 @@ module Footnotes
 
       protected
         def to_table
-          @to_table ||= assigns.inject([]) {|rr, var| rr << [var, escape(assigned_value(var))]}.unshift(['Name', 'Value'])
+          table = assigns.inject([]) do |rr, var|
+            class_name = assigned_value(var).class.name
+            var_name = var.to_s
+            rr << ["<strong>#{var.to_s}</strong>" + "<br /><em>#{class_name}</em>", escape(assigned_value(var).inspect)]
+          end
+
+          table.unshift(['Name', 'Value'])
+          @to_table ||= table
         end
 
         def assigns
@@ -46,8 +53,9 @@ module Footnotes
         end
 
         def assigned_value(key)
-          @controller.instance_variable_get(key).inspect
+          @controller.instance_variable_get(key)
         end
+
     end
   end
 end

--- a/spec/notes/assigns_note_spec.rb
+++ b/spec/notes/assigns_note_spec.rb
@@ -18,7 +18,11 @@ describe Footnotes::Notes::AssignsNote do
   its(:title) {should eql 'Assigns (2)'}
 
   specify {note.send(:assigns).should eql [:@action_has_layout, :@status]}
-  specify {note.send(:to_table).should eql [['Name', 'Value'], [:@action_has_layout, "true"], [:@status, "200"]]}
+  specify {note.send(:to_table).should eql [
+    ["Name", "Value"],
+    ["<strong>@action_has_layout</strong><br /><em>TrueClass</em>", "true"],
+    ["<strong>@status</strong><br /><em>Fixnum</em>", "200"]
+  ]}
 
   describe "Ignored Assigns" do
     before(:each) {Footnotes::Notes::AssignsNote.ignored_assigns = [:@status]}
@@ -32,7 +36,11 @@ describe Footnotes::Notes::AssignsNote do
 
   it "should call #mount_table method with correct params" do
     note.should_receive(:mount_table).with(
-      [['Name', 'Value'], [:@action_has_layout, "true"], [:@status, "200"]], {:summary=>"Debug information for Assigns (2)"})
+      [
+        ["Name", "Value"],
+        ["<strong>@action_has_layout</strong><br /><em>TrueClass</em>", "true"],
+        ["<strong>@status</strong><br /><em>Fixnum</em>", "200"]
+      ], {:summary=>"Debug information for Assigns (2)"})
     note.content
   end
 end


### PR DESCRIPTION
Dunno if you're interested in this... I've done two things to the 'assigns' footnote:

1) Add the class name below the variable name, and present it a little better

2) If the assigned variable is an ActiveRecord::Relation, it'll display it as a table, rather than the raw object-as-string style.

I haven't written tests for the ActiveRecord::Relation case... I'm happy to do it, just not sure what the best approach is? Just stub everything to fake an ActiveRecord::Relation? Or is there a better way?

See before / after screenshots:

![screen shot 2014-07-06 at 10 51 41 am](https://cloud.githubusercontent.com/assets/145042/3487884/5c1a4262-04af-11e4-980f-176437625134.png)
![screen shot 2014-07-06 at 11 37 46 am](https://cloud.githubusercontent.com/assets/145042/3487885/5e010886-04af-11e4-8b21-411c10cf9f1f.png)

Signed-off-by: Joshua Paling joshua.paling@gmail.com
