### PR TITLE
Remove the error occurred by `Footnotes::Notes::LogNote.start!` on Rails 3

### DIFF
--- a/lib/rails-footnotes/notes/log_note.rb
+++ b/lib/rails-footnotes/notes/log_note.rb
@@ -12,7 +12,12 @@ module Footnotes
         self.original_logger = Rails.logger
         note_logger = NoteLogger.new(self.logs)
         note_logger.level = self.original_logger.level
-        note_logger.formatter = self.original_logger.kind_of?(Logger) ? self.original_logger.formatter : ActiveSupport::Logger::SimpleFormatter.new
+        note_logger.formatter =
+          if self.original_logger.kind_of?(Logger)
+            self.original_logger.formatter
+          else
+            defined?(ActiveSupport::Logger) ? ActiveSupport::Logger::SimpleFormatter.new : Logger::SimpleFormatter.new
+          end
         # Rails 3 don't have ActiveSupport::Logger#broadcast so we backported it
         extend_module = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger.broadcast(note_logger) : NoteLogger.broadcast(note_logger)
         Rails.logger = self.original_logger.dup.extend(extend_module)


### PR DESCRIPTION
On Rails 3, `Rails.logger` is not kind of `Logger`, and
`ActiveSupport::Logger::SimpleFormatter` is not defined. Therefore, this
line is output to Rails log.

```
Footnotes Log Exception: uninitialized constant ActiveSupport::Logger
```

Use `Logger::SimpleFormatter` as it is the class correspond to
`ActiveSupport::Logger::SimpleFormatter`.
