### PR TITLE
Limit assigns size inside notes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gem "rake", "~> 13.0"
 gem "rspec-rails", "~> 6.0"
 gem "sprockets-rails", "~> 3.2"
 gem "matrix", "~> 0.4.2"
+
+gem "sqlite3", "~> 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.9-arm64-darwin)
+    sqlite3 (1.6.9-x86_64-linux)
     thor (1.3.0)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -209,6 +211,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec-rails (~> 6.0)
   sprockets-rails (~> 3.2)
+  sqlite3 (~> 1.6)
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/lib/generators/templates/rails_footnotes.rb
+++ b/lib/generators/templates/rails_footnotes.rb
@@ -21,6 +21,9 @@ Footnotes.setup do |f|
   # Change font size :
   # f.font_size = '11px'
 
+  # Change default limit :
+  # f.default_limit = 25
+
   # Allow to open multiple notes :
   # f.multiple_notes = true
 end if defined?(Footnotes) && Footnotes.respond_to?(:setup)

--- a/lib/rails-footnotes.rb
+++ b/lib/rails-footnotes.rb
@@ -34,6 +34,9 @@ module Footnotes
 
     delegate :font_size, :to => Filter
     delegate :font_size=, :to => Filter
+
+    delegate :default_limit, :to => Filter
+    delegate :default_limit=, :to => Filter
   end
 
   def self.before(&block)

--- a/lib/rails-footnotes/filter.rb
+++ b/lib/rails-footnotes/filter.rb
@@ -21,7 +21,8 @@ module Footnotes
     # :multiple_notes => Set to true if you want to open several notes at the same time
     # :lock_top_right => Lock a btn to toggle notes to the top right of the browser
     # :font_size      => CSS font-size property
-    cattr_accessor :no_style, :notes, :prefix, :multiple_notes, :lock_top_right, :font_size
+    # :default_limit  => Default limit for ActiveRecord:Relation in assigns note
+    cattr_accessor :no_style, :notes, :prefix, :multiple_notes, :lock_top_right, :font_size, :default_limit
 
     class << self
       include Footnotes::EachWithRescue

--- a/lib/rails-footnotes/filter.rb
+++ b/lib/rails-footnotes/filter.rb
@@ -5,6 +5,7 @@ module Footnotes
     @@klasses = []
     @@lock_top_right = false
     @@font_size = '11px'
+    @@default_limit = 25
 
     # Default link prefix is textmate
     @@prefix = 'txmt://open?url=file://%s&amp;line=%d&amp;column=%d'

--- a/lib/rails-footnotes/notes/assigns_note.rb
+++ b/lib/rails-footnotes/notes/assigns_note.rb
@@ -42,8 +42,12 @@ module Footnotes
             class_name = assigned_value(var).class.name
             var_name = var.to_s
             var_value = assigned_value(var)
-            var_value = var_value.limit(100) if var_value.is_a?(ActiveRecord::Relation)
-            rr << ["<strong>#{var.to_s}</strong>" + "<br /><em>#{class_name}</em>", escape(var_value.inspect)]
+            var_value_string = if var_value.is_a?(ActiveRecord::Relation) && var_value.limit_value.nil?
+              escape(var_value.limit(20).inspect) + '...'
+            else
+              escape(var_value.inspect)
+            end
+            rr << ["<strong>#{var.to_s}</strong>" + "<br /><em>#{class_name}</em>", var_value]
           end
 
           table.unshift(['Name', 'Value'])

--- a/lib/rails-footnotes/notes/assigns_note.rb
+++ b/lib/rails-footnotes/notes/assigns_note.rb
@@ -42,12 +42,10 @@ module Footnotes
             class_name = assigned_value(var).class.name
             var_name = var.to_s
             var_value = assigned_value(var)
-            var_value_string = if var_value.is_a?(ActiveRecord::Relation) && var_value.limit_value.nil?
-              escape(var_value.limit(Footnotes::Filter.default_limit).inspect) + '...'
-            else
-              escape(var_value.inspect)
+            if var_value.is_a?(ActiveRecord::Relation) && var_value.limit_value.nil?
+              var_value = var_value.limit(Footnotes::Filter.default_limit)
             end
-            rr << ["<strong>#{var.to_s}</strong>" + "<br /><em>#{class_name}</em>", var_value_string]
+            rr << ["<strong>#{var.to_s}</strong>" + "<br /><em>#{class_name}</em>", escape(var_value.inspect)]
           end
 
           table.unshift(['Name', 'Value'])

--- a/lib/rails-footnotes/notes/assigns_note.rb
+++ b/lib/rails-footnotes/notes/assigns_note.rb
@@ -43,7 +43,7 @@ module Footnotes
             var_name = var.to_s
             var_value = assigned_value(var)
             var_value_string = if var_value.is_a?(ActiveRecord::Relation) && var_value.limit_value.nil?
-              escape(var_value.limit(20).inspect) + '...'
+              escape(var_value.limit(Footnotes::Filter.default_limit).inspect) + '...'
             else
               escape(var_value.inspect)
             end

--- a/lib/rails-footnotes/notes/assigns_note.rb
+++ b/lib/rails-footnotes/notes/assigns_note.rb
@@ -47,7 +47,7 @@ module Footnotes
             else
               escape(var_value.inspect)
             end
-            rr << ["<strong>#{var.to_s}</strong>" + "<br /><em>#{class_name}</em>", var_value]
+            rr << ["<strong>#{var.to_s}</strong>" + "<br /><em>#{class_name}</em>", var_value_string]
           end
 
           table.unshift(['Name', 'Value'])

--- a/lib/rails-footnotes/notes/assigns_note.rb
+++ b/lib/rails-footnotes/notes/assigns_note.rb
@@ -41,7 +41,9 @@ module Footnotes
           table = assigns.inject([]) do |rr, var|
             class_name = assigned_value(var).class.name
             var_name = var.to_s
-            rr << ["<strong>#{var.to_s}</strong>" + "<br /><em>#{class_name}</em>", escape(assigned_value(var).inspect)]
+            var_value = assigned_value(var)
+            var_value = var_value.limit(100) if var_value.is_a?(ActiveRecord::Relation)
+            rr << ["<strong>#{var.to_s}</strong>" + "<br /><em>#{class_name}</em>", escape(var_value.inspect)]
           end
 
           table.unshift(['Name', 'Value'])

--- a/lib/rails-footnotes/notes/assigns_note.rb
+++ b/lib/rails-footnotes/notes/assigns_note.rb
@@ -1,3 +1,5 @@
+require "active_record"
+
 module Footnotes
   module Notes
     class AssignsNote < AbstractNote
@@ -40,7 +42,6 @@ module Footnotes
         def to_table
           table = assigns.inject([]) do |rr, var|
             class_name = assigned_value(var).class.name
-            var_name = var.to_s
             var_value = assigned_value(var)
             if var_value.is_a?(ActiveRecord::Relation) && var_value.limit_value.nil?
               var_value = var_value.limit(Footnotes::Filter.default_limit)

--- a/spec/notes/assigns_note_spec.rb
+++ b/spec/notes/assigns_note_spec.rb
@@ -1,20 +1,20 @@
 require "spec_helper"
-require 'action_controller'
+require "action_controller"
 require "rails-footnotes/notes/assigns_note"
+require "support/active_record"
 
 describe Footnotes::Notes::AssignsNote do
-  let(:note) do
-    @controller = double
-    allow(@controller).to receive(:instance_variables).and_return([:@action_has_layout, :@status])
-    @controller.instance_variable_set(:@action_has_layout, true)
-    @controller.instance_variable_set(:@status, 200)
-    Footnotes::Notes::AssignsNote.new(@controller)
+  let(:controller) do
+    double(instance_variables: [:@action_has_layout, :@status]).tap do |c|
+      c.instance_variable_set(:@action_has_layout, true)
+      c.instance_variable_set(:@status, 200)
+    end
   end
-  subject {note}
+  subject(:note) { Footnotes::Notes::AssignsNote.new(controller) }
 
   before(:each) {Footnotes::Notes::AssignsNote.ignored_assigns = []}
 
-  it {should be_valid}
+  it { should be_valid }
 
   describe '#title' do
     subject { super().title }
@@ -46,5 +46,23 @@ describe Footnotes::Notes::AssignsNote do
         ["<strong>@status</strong><br /><em>Integer</em>", "200"]
       ], {:summary=>"Debug information for Assigns (2)"})
     note.content
+  end
+
+  describe "when it is an ActiveRecord::Relation" do
+    let(:controller) do
+      double(instance_variables: [:@widgets]).tap do |c|
+        c.instance_variable_set(:@widgets, Widget.all)
+      end
+    end
+
+    it "should still work" do
+      expect(note).to receive(:mount_table).with(
+        [
+          ["Name", "Value"],
+          ["<strong>@widgets</strong><br /><em>ActiveRecord::Relation</em>", "#&lt;ActiveRecord::Relation []&gt;"],
+        ], {:summary=>"Debug information for Assigns (1)"})
+      expect(note).to be_valid
+      note.content
+    end
   end
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,0 +1,22 @@
+require "active_record"
+
+ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
+
+ActiveRecord::Migration.verbose = false
+
+ActiveRecord::Migration.create_table :widgets do |t|
+  t.string :name
+  t.timestamps
+end
+
+class Widget < ActiveRecord::Base
+end
+
+RSpec.configure do |config|
+  config.around do |example|
+    ActiveRecord::Base.transaction do
+      example.run
+      raise ActiveRecord::Rollback
+    end
+  end
+end


### PR DESCRIPTION
If an assigned value has a large enough contents, it's possible to overwhelm not just the page but the entire server process. (Think ActiveAdmin filling a single ivar with `ModelName.all`, and then trying to print an inspect string that contains every single model in your entire database.) This adds a limit to AR::Relations of 25 records max, configurable in settings.