### PR TITLE
Support frozen string literals

### DIFF
--- a/lib/rails-footnotes/abstract_note.rb
+++ b/lib/rails-footnotes/abstract_note.rb
@@ -169,7 +169,7 @@ module Footnotes
         def hash_to_xml_attributes(hash)
           newstring = ""
           hash.each do |key, value|
-            newstring << "#{key.to_s}=\"#{value.gsub('"','\"')}\" "
+            newstring += "#{key.to_s}=\"#{value.gsub('"','\"')}\" "
           end
           return newstring
         end

--- a/lib/rails-footnotes/filter.rb
+++ b/lib/rails-footnotes/filter.rb
@@ -287,7 +287,7 @@ module Footnotes
         html = ''
         order.uniq!
         order.each do |row|
-          html << "#{row.is_a?(String) ? row : row.to_s.camelize}: #{links[row].join(" | \n")}<br />"
+          html += "#{row.is_a?(String) ? row : row.to_s.camelize}: #{links[row].join(" | \n")}<br />"
         end
         html
       end
@@ -298,7 +298,7 @@ module Footnotes
         content = ''
         each_with_rescue(@notes) do |note|
           next unless note.has_fieldset?
-          content << <<-HTML
+          content += <<-HTML
             <fieldset id="#{note.to_sym}_debug_info" style="display: none">
               <legend>#{note.legend}</legend>
               <div>#{note.content}</div>
@@ -315,7 +315,7 @@ module Footnotes
         javascript = ''
         each_with_rescue(@notes) do |note|
           next unless note.has_fieldset?
-          javascript << close_helper(note)
+          javascript += close_helper(note)
         end
         javascript
       end

--- a/lib/rails-footnotes/notes/log_note.rb
+++ b/lib/rails-footnotes/notes/log_note.rb
@@ -33,9 +33,9 @@ module Footnotes
       def content
         result = '<table>'
           log.compact.each do |l|
-            result << "<tr><td>#{l.gsub(/\e\[.+?m/, '')}</td></tr>"
+            result += "<tr><td>#{l.gsub(/\e\[.+?m/, '')}</td></tr>"
           end
-        result << '</table>'
+        result += '</table>'
         # Restore formatter
         Rails.logger = self.class.original_logger
         result

--- a/lib/rails-footnotes/notes/queries_note.rb
+++ b/lib/rails-footnotes/notes/queries_note.rb
@@ -36,7 +36,7 @@ module Footnotes
           sql_links = []
           sql_links << "<a href=\"javascript:Footnotes.toggle('qtrace_#{index}')\" style=\"color:#00A;\">trace</a>"
 
-          html << <<-HTML
+          html += <<-HTML
           <tr>
             <td>
               <b id="qtitle_#{index}">#{escape(event.type.to_s.upcase)}</b> (#{sql_links.join(' | ')})
@@ -49,7 +49,7 @@ module Footnotes
           </tr>
           HTML
         end
-        html << '</table>'
+        html += '</table>'
         return html
       end
 


### PR DESCRIPTION
Ruby 3.4 [enables](https://bugs.ruby-lang.org/issues/20205) frozen string literal warnings by default. Future versions will make this warning an error. This simple patch gets rid of the warnings by creating new string objects. Technically it is probably better to use StringIO for these big strings, but this is a development only gem so I chose simplicity.